### PR TITLE
Small performance improvement

### DIFF
--- a/PropLineTool_v1/UIOptionPanel.cs
+++ b/PropLineTool_v1/UIOptionPanel.cs
@@ -55,7 +55,7 @@ namespace PropLineTool.UI.OptionPanel
         //private UICheckBox _controlPanelToggle;
         internal UIMultiStateButton _controlPanelToggle;
 
-        private UIPanel[] _specificSettingPages;
+        private readonly UIPanel[] _specificSettingPages;
         
         public static readonly string[] TOOL_MODE_NAMES = new string[]
         {
@@ -363,12 +363,9 @@ namespace PropLineTool.UI.OptionPanel
         public override void Update()
         {
             base.Update();
-            
-            //bool _allThreeToolsNull;
-            bool _allThreeToolsNull = new bool();
-            
+
             //mmmmm-magic!
-            ToolSwitch.PLTToolSwitch.SwitchTools(out _allThreeToolsNull);
+            ToolSwitch.PLTToolSwitch.SwitchTools(out bool _allThreeToolsNull);
 
             if (_allThreeToolsNull)
             {


### PR DESCRIPTION
Some very minor tweaks to reduce amount of code being run per frame when the tool is not active.

Make sure you do thorough testing before merging.

Updates #1 

> If this initial tweak works, I'd suggest publishing to workshop to reduce end user pain, then afterwards consider more performance tuning.
>  
> Ideally use tool events and possibly use a state engine to keep track of state, that way you wouldn't need to do so much per frame.